### PR TITLE
refactor: replace deprecated ioutil packages with os / io

### DIFF
--- a/local-interfaces/handlers/user.go
+++ b/local-interfaces/handlers/user.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -40,10 +40,10 @@ func GetUserScoreHandler(userDataStore UserDataStore) http.HandlerFunc {
 func DeleteUserHandler(userDataStore UserDataStore) http.HandlerFunc {
 	return func(res http.ResponseWriter, req *http.Request) {
 		// Totally trust the client, this is fine (it's not, don't do this)
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 
 		if err != nil {
-			fmt.Println("ioutil.ReadAll(req.Body): ", err)
+			fmt.Println("io.ReadAll(req.Body): ", err)
 			res.WriteHeader(500)
 			return
 		}

--- a/outside-world/README.md
+++ b/outside-world/README.md
@@ -102,7 +102,7 @@ And now we can have our handler read the file every time someone asks (*aside: n
 // server.go
 
 func gslCurrentChampionHandler(res http.ResponseWriter, req *http.Request) {
-	contents, err := ioutil.ReadFile("./champion.txt")
+	contents, err := os.ReadFile("./champion.txt")
 
 	if err != nil {
 		log.Println("Failed to read file:", err)
@@ -121,7 +121,7 @@ func TestGSLCurrentChampionIsTY(t *testing.T) {
 	// I hate everything about this.  Writing this has caused my keyboard
 	// to rebel in anger.  Do not use this.  Do not even think about it
 	// for too long or adverse health effects may arise.
-	contents, err := ioutil.ReadFile("./champion.txt")
+	contents, err := os.ReadFile("./champion.txt")
 
 	if err != nil {
 		t.Fatal("Failed to read file:", err)
@@ -152,7 +152,7 @@ Oof.  This is bad.
 ...but why?
 
 Read this test as if you had no idea what `gslCurrentChampionHandler` did.
-If your head combusts the moment you see "ioutil.ReadFile", then you're
+If your head combusts the moment you see "os.ReadFile", then you're
 doing well.
 
 Seriously, take a moment.  Look at the test.  Imagine you're a fresh new developer
@@ -191,7 +191,7 @@ Let's take another look at the code as-is.
 
 ```go
 func gslCurrentChampionHandler(res http.ResponseWriter, req *http.Request) {
-	contents, err := ioutil.ReadFile("./champion.txt")
+	contents, err := os.ReadFile("./champion.txt")
 
 	if err != nil {
 		log.Println("Failed to read file:", err)
@@ -207,8 +207,8 @@ While this is very few lines of actual code, the current handler has to deal
 with the following:
 
 - What even is HTTP? (res/req parameters)
-- How do I get the data I need? (read a file with ioutil.ReadFile)
-- What even is a file? (ioutil.ReadFile)
+- How do I get the data I need? (read a file with os.ReadFile)
+- What even is a file? (os.ReadFile)
 - What file do I need to read? (champion.txt)
 - What is the format of that file? (literally just the name in this case, but we still need to know that!)
 - What do I do if I can't get the data? (return 500)
@@ -232,8 +232,8 @@ HTTP:
 
 Data:
 
-- What even is a file? (ioutil.ReadFile)
-- How do I get the data I need? (read a file with ioutil.ReadFile)
+- What even is a file? (os.ReadFile)
+- How do I get the data I need? (read a file with os.ReadFile)
 - What file do I need to read? (champion.txt)
 - What is the format of that file? (literally just the name in this case, but we still need to know that!)
 
@@ -259,7 +259,7 @@ func NewGSLDataStore(championFile string) *GSLDataStore {
 
 // GetCurrentChampion returns the name of the current GSL champion
 func (s *GSLDataStore) GetCurrentChampion() (string, error) {
-	contents, err := ioutil.ReadFile(s.championFile)
+	contents, err := os.ReadFile(s.championFile)
 
 	if err != nil {
 		return "", fmt.Errorf("failed to read file: %w", err)
@@ -372,7 +372,7 @@ I want you to pretend that you're a new dev again coming in on this project.  Lo
 two lines of code.
 
 ```golang
-contents, err := ioutil.ReadFile("./champion.txt")
+contents, err := os.ReadFile("./champion.txt")
 ```
 
 ```golang

--- a/outside-world/less-velociraptors/data.go
+++ b/outside-world/less-velociraptors/data.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // GSLDataStore knows how to get GSL data
@@ -19,7 +19,7 @@ func NewGSLDataStore(championFile string) *GSLDataStore {
 
 // GetCurrentChampion returns the name of the current GSL champion
 func (s *GSLDataStore) GetCurrentChampion() (string, error) {
-	contents, err := ioutil.ReadFile(s.championFile)
+	contents, err := os.ReadFile(s.championFile)
 
 	if err != nil {
 		return "", fmt.Errorf("failed to read file: %w", err)

--- a/outside-world/less-velociraptors/server_test.go
+++ b/outside-world/less-velociraptors/server_test.go
@@ -1,14 +1,14 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"net/http/httptest"
 	"testing"
 )
 
 func TestGSLCurrentChampionIsTY(t *testing.T) {
 	// We still have to do this.  I hate my life.
-	contents, err := ioutil.ReadFile("./champion.txt")
+	contents, err := os.ReadFile("./champion.txt")
 
 	if err != nil {
 		t.Fatal("Failed to read file:", err)

--- a/outside-world/no-velociraptors/data.go
+++ b/outside-world/no-velociraptors/data.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // GSLDataStore knows how to get GSL data
@@ -19,7 +19,7 @@ func NewGSLDataStore(championFile string) *GSLDataStore {
 
 // GetCurrentChampion returns the name of the current GSL champion
 func (s *GSLDataStore) GetCurrentChampion() (string, error) {
-	contents, err := ioutil.ReadFile(s.championFile)
+	contents, err := os.ReadFile(s.championFile)
 
 	if err != nil {
 		return "", fmt.Errorf("failed to read file: %w", err)

--- a/outside-world/velociraptors/server.go
+++ b/outside-world/velociraptors/server.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"log"
 	"net/http"
 )
@@ -9,7 +9,7 @@ import (
 func gslCurrentChampionHandler(res http.ResponseWriter, req *http.Request) {
 	// We magically know it's in champion.txt and we magically know it's a plaintext file
 	// that only contains the name with no line break at the end.  This is terrible.
-	contents, err := ioutil.ReadFile("./champion.txt")
+	contents, err := os.ReadFile("./champion.txt")
 
 	if err != nil {
 		log.Println("Failed to read file:", err)

--- a/outside-world/velociraptors/server_test.go
+++ b/outside-world/velociraptors/server_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"net/http/httptest"
 	"testing"
 )
@@ -10,7 +10,7 @@ func TestGSLCurrentChampionIsTY(t *testing.T) {
 	// I hate everything about this.  Writing this has caused my keyboard
 	// to rebel in anger.  Do not use this.  Do not even think about it
 	// for too long or adverse health effects may arise.
-	contents, err := ioutil.ReadFile("./champion.txt")
+	contents, err := os.ReadFile("./champion.txt")
 
 	if err != nil {
 		t.Fatal("Failed to read file:", err)


### PR DESCRIPTION
the `ioutil` package is deprecated as of Go 1.16. The example and description is something still valuable when it comes to learning about Interfaces in Go. Contributing to keeping the code and work updated for Go Version >= 1.16